### PR TITLE
Update studio address and reference to Air

### DIFF
--- a/the-studio.md
+++ b/the-studio.md
@@ -50,7 +50,7 @@ Every Monday, the seniors in the team are invited to attend the Senior Team Meet
 
 ### Address
 
-63 Westgate Rd, Newcastle upon Tyne, NE1 1SG.
+Cathedral Buildings, Dean Street, Newcastle Upon Tyne, United Kingdom, NE1 1PG.
 
 ### Phone Number
 

--- a/welcome-to-komodo.md
+++ b/welcome-to-komodo.md
@@ -15,7 +15,7 @@ On your first day, here's a rough outline of what you will be up to:
    - Jira (_Tasks_)
    - BitBucket and GitHub (_Code Source Control_)
    - LastPass (_Passwords and Secure Notes_)
-   - Air (_HR_)
+   - Mincoffs (_HR_)
    
  - Be introduced to the company, team structure and key persons related to your role
  - Setup your development environment (see [Our Tools And Tech](our-tools-and-tech.md))


### PR DESCRIPTION
Updated the studio address from the old studio location to the new one. Updated one reference to Air which was missed in a previous PR.

New studio address:
![Screenshot 2022-04-12 at 08 47 30](https://user-images.githubusercontent.com/60875460/162908541-c32c02d3-ccd2-4d68-bd07-d0e279933765.png)

Changed old reference to Air to 'Mincoffs':
![Screenshot 2022-04-12 at 08 47 39](https://user-images.githubusercontent.com/60875460/162908559-4213bca2-0288-4212-be61-9b549bba08ac.png)

