### PR TITLE
Add severity to bug reporting page

### DIFF
--- a/bug-reporting.md
+++ b/bug-reporting.md
@@ -40,6 +40,15 @@ In general, the following template should suffice for reporting a bug.
 
 > Links to screenshots / videos that demonstrate the issue.
 
+## Severity
+
+> This should explain the severity of an issue using the below severity definitions. 
+- **Blocker** - Not only is the issue Critical, but it prevents other defects from being resolved, and new functionality and feature development.
+- **Critical** - The issue affects critical functionality or critical data. It does not have a workaround. *Example: Unsuccessful installation, complete failure of a feature.*
+- **Major** - The issue affects major functionality or major data. It has a workaround but is not obvious and is difficult. *Example: A feature is not functional from one module but the task is doable if 10 complicated indirect steps are followed in another module/s.*
+- **Minor** - The issue affects minor functionality or non-critical data. It has an easy workaround. *Example: A minor feature that is not functional in one module but the same task is easily doable from another module.*
+- **Trivial** - The issue does not affect functionality or data. It does not even need a workaround. It does not impact productivity or efficiency. *Example: Minor layout discrepancies, spelling/grammatical errors.*
+
 ---
 
 If you need a "tailored" bug reporting template, checkout https://github.com/devspace/awesome-github-templates.


### PR DESCRIPTION
# Add severity to bug reporting page

## Description
We're going to start using a severity field across our Jira boards so this PR adds the definitions of each severity level to the `Bug Reporting` page on the handbook.


## Screenshots
<img width="1248" alt="Screenshot 2023-04-14 at 09 04 55" src="https://user-images.githubusercontent.com/60875460/231983347-7080b8ba-3a6a-472d-b843-9704b8c0ce59.png">
