### PR TITLE
Remove ex-employees, replace LastPass with Bitwarden

### DIFF
--- a/onboarding-new-staff.md
+++ b/onboarding-new-staff.md
@@ -115,8 +115,6 @@ Once the team member has had their hardware provisioned, the next stage is to go
      - Development
        - PHP - Laravel, Symfony, WordPress
          - Scott Salisbury (Head of Web Development)
-       - Frontend / JS - React / Node
-         - Daniel Carney (Senior Developer)
        - Mobile / React Native
          - Mike Flowers (Head of Mobile Development)
  - Talk about probation, probation rules and restrictions and review policy, expectations.

--- a/onboarding-new-staff.md
+++ b/onboarding-new-staff.md
@@ -7,13 +7,13 @@
 Upon arranging a start date with a new development / qa team member at the company, please ensure to do the following.
 
 1. Add the start date and time as a meeting invite to the calendar of the new team member's manager. 
-  - For now, this can be added to Ian Outterside's calendar. 
+  - For now, this can be added to Scott Salisbury's calendar. 
   - Book out a 1 hour meeting to provision the laptop
   - Book out a second 1 hour meeting to do introductions and onboarding (including Nicola O'Neill from a HR perspective)
 2. Organise delivery of a new Macbook Pro, together with any additional peripherals (keyboard, mouse, monitor, USB adapters etc) to the new team member in advance of their start date.
 3. Send an email to the new team member informing them of this hardware's arrival and expected delivery date. 
-  - Inform the new team member **they must not turn the machine on** until they have spoken to Ian Outterside and he has provisioned the machine.
-  - Under no circumstances must they change the laptop configuration or install any software until they have spoken to Ian Outterside.
+  - Inform the new team member **they must not turn the machine on** until they have spoken to Scott Salisbury and he has provisioned the machine.
+  - Under no circumstances must they change the laptop configuration or install any software until they have spoken to Scott Salisbury.
   - They may unpackaged the laptop and charge it up in advance.
 4. Book in a meeting for the new team member's probation review for 3 months from the date of their start.
 
@@ -28,7 +28,7 @@ Before speaking to the new team member on the morning they start, there are a nu
  - JIRA
  - Harvest
  - Mincoffs
- - LastPass
+ - Bitwarden
 
 ## Setting up hardware (Macs)
 
@@ -40,7 +40,7 @@ Perform the following steps in order to being the setup process.
 
 1. Turn on the mac.
 2. Configure the mac to use UK timezone, UK keyboard etc. Connect to Wifi.
-3. Make the first account an Administrator account, using the name Administrator. Set the password to be the password as recorded under the lastpass entry called `Office Mac Desktop / Laptop Administrator Password` which is in the shared folder `Shared-MasterAccounts\Komodo Staff\Machines`. 
+3. Make the first account an Administrator account, using the name Administrator. Set the password to be the password as recorded under the Bitwarden entry called `Office Mac Desktop / Laptop Administrator Password` which is in the shared folder `Shared-MasterAccounts\Komodo Staff\Machines`. 
 4. Disable location services, Siri, and do not allow Touch ID to log in.
 5. Do not create an Apple account (instead select to skip).
 6. Do not enable additional tracking, or sending crash reports to Apple.
@@ -89,7 +89,7 @@ At this point, you should be logged into the first account added to the Mac, and
 12. Visit `https://gist.github.com/ianoshorty/cf9174fb7b09fcc145170313e53f7314` and run the commands in the script to install our usual software suite.
 13. Go to "System Preferences -> Security & Privacy -> FileVault".
 14. Enable FileVault, DO NOT use iCloud but instead generate a recovery key.
-15. Store the recovery key as a secure note in LastPass under the `Shared-MasterAccounts\Komodo Staff\FileVaults` shared group with the Mac's device name.
+15. Store the recovery key as a secure note in Bitwarden under the `Shared-MasterAccounts\Komodo Staff\FileVaults` shared group with the Mac's device name.
 16. Apply and lock.
 17. If time allows, apply any **SECURITY ONLY* fixes to the mac, but **DO NOT* upgrade it to a newer OS version (e.g dont upgrade Catalina to Big Sur).
 18. Ensure that the new hardware's details are fully recorded in the Google Sheet. 
@@ -104,22 +104,19 @@ Once the team member has had their hardware provisioned, the next stage is to go
  - Talk through the key team members
    - Directors
      - Andy Greener (MD)
-     - Armin Talic (CD)
      - Jason Christie (PD)
-     - Ian Outterside (TD)
    - Management
      - Chris Jones (Client Services)
      - Phoebe Dowley (Account Management)
      - Nicola O'Neill (Office Management)
    - Teams & Leads
      - Design
-       - James Tabiner - aka Tabs (Senior Designer)
        - Thomas Wood - aka Woody (Senior Designer)
      - Development
        - PHP - Laravel, Symfony, WordPress
-         - Scott Salisbury (Senior Developer)
+         - Scott Salisbury (Head of Web Development)
        - Frontend / JS - React / Node
-         - Chris Neale (Senior Developer)
+         - Daniel Carney (Senior Developer)
        - Mobile / React Native
          - Mike Flowers (Senior Developer)
  - Talk about probation, probation rules and restrictions and review policy, expectations.

--- a/onboarding-new-staff.md
+++ b/onboarding-new-staff.md
@@ -26,7 +26,7 @@ Before speaking to the new team member on the morning they start, there are a nu
    - Ensure to add their user accounts to the `Office` (aka `Studio`) and `Devs` groups at [https://admin.google.com/ac/groups](https://admin.google.com/ac/groups)
  - Slack
  - JIRA
- - Harvest
+ - Float
  - Mincoffs
  - Bitwarden
 

--- a/onboarding-new-staff.md
+++ b/onboarding-new-staff.md
@@ -118,7 +118,7 @@ Once the team member has had their hardware provisioned, the next stage is to go
        - Frontend / JS - React / Node
          - Daniel Carney (Senior Developer)
        - Mobile / React Native
-         - Mike Flowers (Senior Developer)
+         - Mike Flowers (Head of Mobile Development)
  - Talk about probation, probation rules and restrictions and review policy, expectations.
  - Talk about HR elements, when you're paid, booking holiday etc.
  - Walk through and confirm clear and thorough understanding of the [Security policy](security-policy.md) at Komodo.

--- a/security-policy.md
+++ b/security-policy.md
@@ -6,11 +6,11 @@ Security is of paramount importance here at Komodo, and we expect you to follow 
 
 ## Password Policy
 
-We employ [LastPass](https://lastpass.com/?ac=1&lpnorefresh=1) in the business to create and store passwords. 
+We employ [Bitwarden](https://bitwarden.com/) in the business to create and store passwords. 
 
-If you are [registering for any accounts](where-is.md) either on behalf of the business (e.g. such as a new tool or service) or for yourself for a business function (such as JIRA), we expect you to generate a random password from LastPass. This password should also be stored in LastPass.
+If you are [registering for any accounts](where-is.md) either on behalf of the business (e.g. such as a new tool or service) or for yourself for a business function (such as JIRA), we expect you to generate a random password from Bitwarden. This password should also be stored in Bitwarden.
 
-If the password you are creating is related to a project rather than yourself, ensure to store it as part of the `Shared-Projects` group in LastPass. If you don’t have access to the group, contact a member of management for access.
+If the password you are creating is related to a project rather than yourself, ensure to store it as part of the `Shared-Projects` group in Bitwarden. If you don’t have access to the group, contact a member of management for access.
 
 ## Two-Factor Everywhere
 
@@ -20,7 +20,7 @@ Please ensure that **for every account you employ related to the business, you a
 
 ## Machine Security and Installed Applications
 
-On your first day you will be asked to set a new password for your office Mac. Please ensure that once set, you create a LastPass shared note with `ian@komododigital.co.uk` including your Mac Password. This is necessary in case we require emergency access to your Mac.
+On your first day you will be asked to set a new password for your office Mac. Please ensure that once set, you create a Bitwarden shared note with `scott@komododigital.co.uk` including your Mac Password. This is necessary in case we require emergency access to your Mac.
 
 >If at any point you update your Mac login password, ensure to share the updated one with management.
 
@@ -30,15 +30,15 @@ If in doubt, talk to management.
 
 ## SSH Keys
 
-Please ensure that your private and public SSH keys are in LastPass as a secure note, again shared with `ian@komododigital.co.uk`. If you have a password for them, ensure to include the password on the note. This is necessary in case access to servers / services is needed in an emergency and your Mac is unavailable.
+Please ensure that your private and public SSH keys are in Bitwarden as a secure note, again shared with `scott@komododigital.co.uk`. If you have a password for them, ensure to include the password on the note. This is necessary in case access to servers / services is needed in an emergency and your Mac is unavailable.
 
 If you need help with how to setup an SSH Key, follow GitHub’s guide at [https://help.github.com/en/enterprise/2.15/user/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent](https://help.github.com/en/enterprise/2.15/user/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
 
 ## Sharing Credentials (internal & external)
 
-The only acceptable method of digitally directly sharing credentials with clients / customers is via a LastPass secure note. If you are unsure how to create one, shout up in the office and someone will give you a hand.
+The only acceptable method of digitally directly sharing credentials with clients / customers is via a Bitwarden secure note. If you are unsure how to create one, shout up in the office and someone will give you a hand.
 
-Internally, shared credentials should be in the relevant project folder in LastPass.
+Internally, shared credentials should be in the relevant project folder in Bitwarden.
 
 You may share credentials quickly via Slack internally, provided you immediately delete the message upon successful receipt by the recipient.
 
@@ -64,7 +64,7 @@ The company does have an account with a VPN provider. When working off site on a
 
 # Project / Code Security
 
-Any project related credentials should be stored in LastPass and **never, ever committed into GIT**. If you discover credentials have been added to GIT by accident, please report this immediately so we can take the appropriate action to revoke the security credentials.
+Any project related credentials should be stored in Bitwarden and **never, ever committed into GIT**. If you discover credentials have been added to GIT by accident, please report this immediately so we can take the appropriate action to revoke the security credentials.
 
 This includes, but is not limited to:
 
@@ -76,7 +76,7 @@ Further to this, database copies / backups and log files should also **never, ev
 
 # WiFi, Mobile Devices & Guests
 
-Personal devices and non-company hardware is forbidden from access to the `Komodo Internal` WiFi network. Please connect these to the `Komodo Guest` network, the details of which are in LastPass. Only office hardware should be connected to the `Komodo Internal` network.
+Personal devices and non-company hardware is forbidden from access to the `Komodo Internal` WiFi network. Please connect these to the `Komodo Guest` network, the details of which are in Bitwarden. Only office hardware should be connected to the `Komodo Internal` network.
 
 >There are exceptions to this - if required please talk to management. 
 

--- a/security-policy.md
+++ b/security-policy.md
@@ -10,7 +10,7 @@ We employ [Bitwarden](https://bitwarden.com/) in the business to create and stor
 
 If you are [registering for any accounts](where-is.md) either on behalf of the business (e.g. such as a new tool or service) or for yourself for a business function (such as JIRA), we expect you to generate a random password from Bitwarden. This password should also be stored in Bitwarden.
 
-If the password you are creating is related to a project rather than yourself, ensure to store it as part of the `Shared-Projects` group in Bitwarden. If you don’t have access to the group, contact a member of management for access.
+If the password you are creating is related to a project rather than yourself, ensure to store it in the respective project's folder in Bitwarden e.g `Collections\Projects\{Project Name}`. If you don’t have access to the group, contact a member of management for access.
 
 ## Two-Factor Everywhere
 

--- a/welcome-to-komodo.md
+++ b/welcome-to-komodo.md
@@ -11,7 +11,7 @@ On your first day, here's a rough outline of what you will be up to:
  - Get your machine setup with standard accounts
    - Gmail and Google Apps (_Email & Docs_)
    - Slack (_Office Chat_)
-   - Harvest (_Time Tracking_)
+   - Float (_Time Tracking_)
    - Jira (_Tasks_)
    - BitBucket and GitHub (_Code Source Control_)
    - Bitwarden (_Passwords and Secure Notes_)

--- a/welcome-to-komodo.md
+++ b/welcome-to-komodo.md
@@ -14,7 +14,7 @@ On your first day, here's a rough outline of what you will be up to:
    - Harvest (_Time Tracking_)
    - Jira (_Tasks_)
    - BitBucket and GitHub (_Code Source Control_)
-   - LastPass (_Passwords and Secure Notes_)
+   - Bitwarden (_Passwords and Secure Notes_)
    - Mincoffs (_HR_)
    
  - Be introduced to the company, team structure and key persons related to your role

--- a/where-is.md
+++ b/where-is.md
@@ -52,11 +52,11 @@ Certain projects have backups exported to Amazon S3 (for example, the College of
 >Login to Amazon AWS Console at **[https://console.aws.amazon.com/](https://console.aws.amazon.com/)**.
 
 
-## Passwords, SSH Keys, Development Certificates, Secure Credentials? LastPass.
+## Passwords, SSH Keys, Development Certificates, Secure Credentials? Bitwarden.
 
-All secure credentials should be stored in LastPass. For project related credentials, ensure they are placed within a shared folder for that project.
+All secure credentials should be stored in Bitwarden. For project related credentials, ensure they are placed within a shared folder for that project.
 
-Items that absolutely should be stored in LastPass (and NOT ANYWHERE ELSE) include:
+Items that absolutely should be stored in Bitwarden (and NOT ANYWHERE ELSE) include:
 
  - Passwords
  - SSH Keys (private and public)
@@ -64,7 +64,7 @@ Items that absolutely should be stored in LastPass (and NOT ANYWHERE ELSE) inclu
  - User accounts
  - API Keys
 
->Login to LastPass at **[https://lastpass.com/?ac=1&lpnorefresh=1](https://lastpass.com/?ac=1&lpnorefresh=1)**
+>Login to Bitwarden at **[https://vault.bitwarden.com/#/login](https://vault.bitwarden.com/#/login)**
 
 ## Time Tracking? Harvest.
 

--- a/where-is.md
+++ b/where-is.md
@@ -66,11 +66,11 @@ Items that absolutely should be stored in Bitwarden (and NOT ANYWHERE ELSE) incl
 
 >Login to Bitwarden at **[https://vault.bitwarden.com/#/login](https://vault.bitwarden.com/#/login)**
 
-## Time Tracking? Harvest.
+## Time Tracking? Float.
 
-Generally, your time on projects needs to be recorded. This is done on Harvest, which you can log into using your Google Apps / Gmail account. If you are not sure where to track your time, please contact an AM / PM.
+Generally, your time on projects needs to be recorded. This is done on Float, which you can log into using your Google Apps / Gmail account. If you are not sure where to track your time, please contact an AM / PM.
 
->Login to Harvest at **[https://id.getharvest.com/accounts](https://id.getharvest.com/accounts)**
+>Login to Float at **[https://komodo.float.com/login](https://komodo.float.com/login)**
 
 ## Booking Holiday / HR? Mincoffs.
 


### PR DESCRIPTION
# 

![giphy (1)](https://github.com/KomodoHQ/komodo-operations-handbook/assets/110092358/73d343c1-871c-49a7-a502-4c6d5eb5d100)

## Description

Remove employees who no longer work at Komodo. Updates to replace LastPass with Bitwarden throughout the documentation.

## Issues

Should resolve the following issues:
https://github.com/KomodoHQ/komodo-operations-handbook/issues/22
https://github.com/KomodoHQ/komodo-operations-handbook/issues/21
https://github.com/KomodoHQ/komodo-operations-handbook/issues/20
https://github.com/KomodoHQ/komodo-operations-handbook/issues/19

## Checklist

- [x] Ticket has been moved to Peer Review
- [x] The `develop` branch has been merged into this branch and conflicts resolved
- [x] All existing tests are passing
- [x] Manual testing has been completed
- [x] Automated tests have been added where necessary
- [x] Documentation has been updated where necessary